### PR TITLE
Add support for Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     }
   ],
   "engines": {
-    "node": "^14.x || ^16.x",
+    "node": "^14.x || ^16.x || ^18.x",
     "npm": " ^7.x || ^8.x"
   },
   "repository": {


### PR DESCRIPTION
[prisma-redis-middleware](https://github.com/Asjas/prisma-redis-middleware) already works just fine on Node 18, so this version should be added to the engines property to allow others to install and run this dependency without error messages.

Thanks!