### PR TITLE
Add wildcard to invalidate more references

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export const createPrismaRedisCache = ({
 
       // If we successfully executed the Mutation we clear and invalidate the cache for the Prisma model
       if (defaultMutationMethods.includes(params.action as PrismaMutationAction)) {
-        await cache.invalidateAll(`${params.model}~*`);
+        await cache.invalidateAll(`*${params.model}~*`);
       }
     }
 


### PR DESCRIPTION
This includes keying from a keying redis option

As some redis will key the keys. to make subsets for parsing faster

this fixes it by just adding a "*"
