### PR TITLE
cacheTime may be a function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export type MemoryStorageOptions = {
   log?: any;
 };
 
+export type TtlFunction = (data: any) => number;
+
 export type CreatePrismaRedisCache = {
   models?: {
     model: string;
@@ -72,7 +74,7 @@ export type CreatePrismaRedisCache = {
         type: "memory";
         options?: MemoryStorageOptions;
       };
-  cacheTime?: number;
+  cacheTime?: number| TtlFunction;
   excludeModels?: string[] | Prisma.ModelName[];
   excludeMethods?: PrismaQueryAction[];
   onError?: (key: string) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type CreatePrismaRedisCache = {
         type: "memory";
         options?: MemoryStorageOptions;
       };
-  cacheTime?: number| TtlFunction;
+  cacheTime?: number | TtlFunction;
   excludeModels?: string[] | Prisma.ModelName[];
   excludeMethods?: PrismaQueryAction[];
   onError?: (key: string) => void;


### PR DESCRIPTION
Awesome library!  Very convenient!

the cacheTime field at the model layer is passed through to async-cache-dedup's define() method as-is.
This means that we should handle the fact that async-cache-dedup allows the ttl to be a _function_ that
receives the data to be cached and returns the appropriate ttl as a number.

We've tested it using `ts-ignore` directives to get typescript to stop complaining and everything works as
expected, but `ts-ignore` is a bad idea in the long-term.  This is a little PR to change types.ts to reflect 
the possibility of a TTL function.  
