### PR TITLE
model cacheTime should be TTlFunction

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type CreatePrismaRedisCache = {
   models?: {
     model: string;
     cacheKey?: string;
-    cacheTime?: number;
+    cacheTime?: number | TtlFunction;
     excludeMethods?: PrismaQueryAction[];
   }[];
   storage?:
@@ -74,7 +74,7 @@ export type CreatePrismaRedisCache = {
         type: "memory";
         options?: MemoryStorageOptions;
       };
-  cacheTime?: number | TtlFunction;
+  cacheTime?: number;
   excludeModels?: string[] | Prisma.ModelName[];
   excludeMethods?: PrismaQueryAction[];
   onError?: (key: string) => void;


### PR DESCRIPTION
Sorry about this!  I accidentally put the TtlFunction reference in the wrong place for the PR when I had it in the right place in the temp change I made to our project to make the TS type checker happy.  The _model_ cacheTime can be a function, the _global_ cacheTime cannot.
