### PR TITLE
Invalidate related models when mutating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 # Ignore Prisma SQLite database
 dev.db
 dev.db-journal
+
+# IntelliJ IDEA project files
+.idea

--- a/README.md
+++ b/README.md
@@ -147,13 +147,14 @@ Options:
   - `cacheKey`: (optional) string. Default is the model value.
   - `cacheTime`: (optional) number (in seconds).
   - `excludeMethods`: (optional) (string) an array of Prisma methods to exclude from being cached for this model.
+  - `invalidateRelated`: (optional) (string) an array of Prisma models to invalidate when mutating this model.
 
     Example:
 
     ```js
     createPrismaRedisCache({
       models: [
-        { model: "User", cacheTime: 60 },
+        { model: "User", cacheTime: 60, invalidateRelated: ["Post"] },
         { model: "Post", cacheKey: "article", excludeMethods: ["findFirst"] },
       ],
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,10 +60,11 @@ export type TtlFunction = (data: any) => number;
 
 export type CreatePrismaRedisCache = {
   models?: {
-    model: string;
+    model: string | Prisma.ModelName;
     cacheKey?: string;
     cacheTime?: number | TtlFunction;
     excludeMethods?: PrismaQueryAction[];
+    invalidateRelated?: string[] | Prisma.ModelName[];
   }[];
   storage?:
     | {


### PR DESCRIPTION
This feature allows to define which related models should be invalidated when mutating model. Very useful when mutating models with n:m relations.