### PR TITLE
Add custom transformer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ Options:
       });
       ```
 
+- `transformer`: (optional) the transformer to used to serialize and deserialize the cache entries. It must be an object
+  with the following methods:
+
+  - `serialize`: a function that receives the result of the original function and returns a serializable object.
+  - `deserialize`: a function that receives the serialized object and returns the original result.
+
+  - Default is `undefined`, so the default transformer is used.
+
+    Example
+
+    ```js
+    import superjson from "superjson";
+
+    createPrismaRedisCache({
+      transformer: {
+        serialize: (result) => superjson.serialize(result),
+        deserialize: (serialized) => superjson.deserialize(serialized),
+      },
+    });
+    ```
+
 ## Debugging
 
 You can pass functions for `onMiss`, `onHit`, `onError` and `onDedupe` to `createPrismaRedisCache` which can then be

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export const createPrismaRedisCache = ({
   cacheTime = DEFAULT_CACHE_TIME,
   excludeModels = [],
   excludeMethods = [],
+  transformer,
 }: CreatePrismaRedisCache) => {
   // Default options for "async-cache-dedupe"
   const cacheOptions = {
@@ -33,6 +34,7 @@ export const createPrismaRedisCache = ({
     onMiss,
     storage,
     ttl: cacheTime,
+    transformer,
   };
 
   const cache: any = createCache(cacheOptions);

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,4 +85,8 @@ export type CreatePrismaRedisCache = {
   onHit?: (key: string) => void;
   onMiss?: (key: string) => void;
   onDedupe?: (key: string) => void;
+  transformer?: {
+    serialize: (data: any) => any;
+    deserialize: (data: any) => any;
+  };
 };


### PR DESCRIPTION
Add custom transformer options. It depends on custom transformer options of `async-cache-dedupe`.

This PR allows cached data to be serialized and deserialized using custom functions or external libraries such as SuperJSON. This enhancement provides developers with greater flexibility and control over the caching process, potentially leading to compatibility with complex data types.

This PR resolves #382 

## Code Expample (with SuperJSON)

```ts
import Prisma from "prisma";
import { PrismaClient } from "@prisma/client";
import SuperJSON from "superjson";
import { createPrismaRedisCache } from "prisma-redis-middleware";
import Redis from "ioredis";

const redis = new Redis();

const prisma = new PrismaClient();

const cacheMiddleware: Prisma.Middleware = createPrismaRedisCache({
  models: [
    { model: "User", excludeMethods: ["findMany"] },
    { model: "Post", cacheTime: 180, cacheKey: "article" },
  ],
  storage: { type: "redis", options: { client: redis, invalidation: { referencesTTL: 300 }, log: console } },
  cacheTime: 300,
  excludeModels: ["Product", "Cart"],
  excludeMethods: ["count", "groupBy"],
  onHit: (key) => {
    console.log("hit", key);
  },
  onMiss: (key) => {
    console.log("miss", key);
  },
  onError: (key) => {
    console.log("error", key);
  },
  // Custom transformer options here.
  transformer: {
    serialize: (data: Object) => SuperJSON.serialize(data),
    deserialize: (data: SuperJSONResult) => SuperJSON.deserialize(data),
  },
});

prisma.$use(cacheMiddleware);
```