### PR TITLE
fix(depx): support node 20.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@size-limit/preset-small-lib": "8.2.4",
         "@types/ioredis-mock": "8.2.2",
         "@vitest/coverage-c8": "0.32.0",
+        "@vitest/coverage-v8": "0.32.0",
         "c8": "7.14.0",
         "husky": "8.0.3",
         "ioredis-mock": "8.7.0",
@@ -32,7 +33,7 @@
         "vitest": "0.32.0"
       },
       "engines": {
-        "node": "^16.x || ^18.x",
+        "node": "^16.x || ^18.x || ^20.x",
         "npm": "^7.x || ^8.x || ^9.x"
       }
     },
@@ -3701,6 +3702,31 @@
       },
       "peerDependencies": {
         "vitest": ">=0.30.0 <1"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.32.0.tgz",
+      "integrity": "sha512-VXXlWq9X/NbsoP/l/CHLBjutsFFww1UY1qEhzGjn/DY7Tqe+z0Nu8XKc8im/XUAmjiWsh2XV7sy/F0IKAl4eaw==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "magic-string": "^0.30.0",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.32.0 <1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -19927,6 +19953,25 @@
         "magic-string": "^0.30.0",
         "picocolors": "^1.0.0",
         "std-env": "^3.3.2"
+      }
+    },
+    "@vitest/coverage-v8": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.32.0.tgz",
+      "integrity": "sha512-VXXlWq9X/NbsoP/l/CHLBjutsFFww1UY1qEhzGjn/DY7Tqe+z0Nu8XKc8im/XUAmjiWsh2XV7sy/F0IKAl4eaw==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "magic-string": "^0.30.0",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
       }
     },
     "@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@size-limit/preset-small-lib": "8.2.4",
     "@types/ioredis-mock": "8.2.2",
     "@vitest/coverage-c8": "0.32.0",
+    "@vitest/coverage-v8": "0.32.0",
     "c8": "7.14.0",
     "husky": "8.0.3",
     "ioredis-mock": "8.7.0",
@@ -73,7 +74,7 @@
     }
   ],
   "engines": {
-    "node": "^16.x || ^18.x",
+    "node": "^16.x || ^18.x || ^20.x",
     "npm": "^7.x || ^8.x || ^9.x"
   },
   "repository": {


### PR DESCRIPTION
### What problem does this PR solve?

- Try using the Node `20.x` version and check if everything works fine. You may need to update the engine support.

### How does this PR solve it?

- Updating engine support: The pull request modifies the engine support configuration to include the required version. This ensures that the project is compatible with the specified engine version, such as Node 20.x.

- Updating Vite packages: The pull request also updates certain Vite packages to their latest versions. This is necessary to incorporate bug fixes, feature enhancements, and ensure compatibility with the updated engine support.
