### PR TITLE
improve: port middleware to extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,157 @@
+import { Prisma } from "@prisma/client";
+import { createCache } from "async-cache-dedupe";
+import { defaultCacheMethods, defaultMutationMethods } from "./cacheMethods";
+import type { CreatePrismaRedisCache, PrismaAction, PrismaMutationAction, PrismaQueryAction } from "./types";
+
+const DEFAULT_CACHE_TIME = 0;
+
+const createPrismaRedisCache = ({
+  models,
+  onDedupe,
+  onError,
+  onHit,
+  onMiss,
+  storage,
+  cacheTime = DEFAULT_CACHE_TIME,
+  excludeModels = [],
+  excludeMethods = [],
+  transformer,
+}: CreatePrismaRedisCache) =>
+  Prisma.defineExtension((client) => {
+    // Default options for "async-cache-dedupe"
+    const cacheOptions = {
+      onDedupe,
+      onError,
+      onHit,
+      onMiss,
+      storage,
+      ttl: cacheTime,
+      transformer,
+    };
+
+    const cache = createCache(cacheOptions);
+
+    return client.$extends({
+      name: "prisma-extension-redis-cache",
+      query: {
+        async $allOperations({ args: queryArgs, model, operation, query }) {
+          let result;
+
+          if (!model) {
+            return query(queryArgs);
+          }
+
+          // This function is used by `async-cache-dedupe` to fetch data when the cache is empty
+          const fetchFromPrisma = async (args: typeof queryArgs) => {
+            return query(args);
+          };
+
+          // Do not cache any Prisma method specified in the excludeMethods option
+          const excludedCacheMethods: PrismaAction[] = defaultCacheMethods.filter((cacheMethod) => {
+            return excludeMethods.includes(cacheMethod);
+          });
+
+          // Do not cache any Prisma method that has been excluded
+          if (!excludedCacheMethods?.includes(operation as PrismaAction)) {
+            // Add a cache function for each model specified in the models option
+            models?.forEach(({ model: cachedModel, cacheTime, cacheKey, excludeMethods }) => {
+              // Only define the cache function for a model if it doesn't exist yet and hasn't been excluded
+              if (
+                !cache[cachedModel] &&
+                cachedModel === model &&
+                !excludeModels?.includes(model) &&
+                !excludeMethods?.includes(operation as PrismaQueryAction)
+              ) {
+                cache.define(
+                  model,
+                  {
+                    references: ({ model }: { model: string }, key: string) => {
+                      return [`${cacheKey || model}~${key}`];
+                    },
+                    ttl: cacheTime || cacheOptions.ttl,
+                  },
+                  async function modelsFetch({ cb, args }: { cb: typeof query; args: typeof queryArgs }) {
+                    result = await cb(args);
+
+                    return result;
+                  },
+                );
+              }
+            });
+
+            // For each defined model in `models` we check if they defined any caching methods to be excluded
+            const excludedCacheMethodsInModels = models?.find(({ model: cachedModel, excludeMethods }) => {
+              return cachedModel === model && excludeMethods?.length;
+            });
+
+            // Do not define a cache function for any Prisma model if it already exists
+            // Do not define the cache function for a model if it was excluded in `defaultExcludeCacheModels`
+            // Do not define a cache function if the Prisma method was exluded in `models`
+            if (
+              !cache[model] &&
+              !excludeModels?.includes(model) &&
+              !excludedCacheMethodsInModels?.excludeMethods?.includes(operation as PrismaQueryAction)
+            ) {
+              cache.define(
+                model,
+                {
+                  references: ({ model }: { model: string }, key: string) => {
+                    return [`${model}~${key}`];
+                  },
+                },
+                async function modelFetch({ cb, args }: { cb: typeof query; args: typeof queryArgs }) {
+                  result = await cb(args);
+
+                  return result;
+                },
+              );
+            }
+          }
+
+          // Get the cache function relating to the Prisma model
+          const cacheFunction = cache[model];
+
+          // Only cache the data if the Prisma model hasn't been excluded and if the Prisma method wasn't excluded either
+          if (
+            !excludeModels?.includes(model) &&
+            !excludedCacheMethods?.includes(operation as PrismaAction) &&
+            !defaultMutationMethods?.includes(operation as PrismaMutationAction) &&
+            typeof cacheFunction === "function"
+          ) {
+            try {
+              result = await cacheFunction({ cb: fetchFromPrisma, queryArgs });
+            } catch (err) {
+              // If we fail to fetch it from the cache (network error, etc.) we will query it from the database
+              result = await fetchFromPrisma(queryArgs);
+
+              console.error(err);
+            }
+          } else {
+            // Query the database for any Prisma method (mutation method) or Prisma model we excluded from the cache
+            result = await fetchFromPrisma(queryArgs);
+
+            // If we successfully executed the Mutation we clear and invalidate the cache for the Prisma model
+            if (defaultMutationMethods.includes(operation as PrismaMutationAction)) {
+              await cache.invalidateAll(`*${model}~*`);
+
+              await Promise.all(
+                (models || [])
+                  .filter(({ model }) => model === model)
+                  .map(async ({ invalidateRelated }) => {
+                    if (invalidateRelated) {
+                      await Promise.all(
+                        invalidateRelated.map(async (relatedModel) => cache.invalidateAll(`*${relatedModel}~*`)),
+                      );
+                    }
+                  }),
+              );
+            }
+          }
+
+          return result;
+        },
+      },
+    });
+  });
+
+export default createPrismaRedisCache;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client/extension";
 import { createCache } from "async-cache-dedupe";
 import { defaultCacheMethods, defaultMutationMethods } from "./cacheMethods";
 import type { CreatePrismaRedisCache, PrismaAction, PrismaMutationAction, PrismaQueryAction } from "./types";

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, assert, describe, expect, test, vi } from "vitest";
+import type Redis from "ioredis";
+import MockRedis from "ioredis-mock";
+import createPrismaRedisCache from "../src/extension";
+
+// Create the mock Redis instance we need
+// Do some funky shit to get TypeScript to be happy 😫
+const mockRedis: unknown = new MockRedis();
+const redis = mockRedis as Redis;
+
+
+afterEach(async () => {
+  await redis.flushall();
+});
+
+// Do some setup stuff
+const dbValue = { key: "test result" };
+const model1 = "User";
+const model2 = "Post";
+const action1 = "findUnique";
+const action2 = "findFirst";
+
+describe.each<{
+  args: { where: { foo: string } };
+  cacheTime: number;
+  cacheKey1: string;
+  cacheKey2: string;
+}>([
+  {
+    args: { where: { foo: "bar" } },
+    cacheTime: 2000, // 2 seconds
+    cacheKey1: `${model1}~{"params":{"operation":"${action1}","args":{"where":{"foo":"bar"}},"model":"${model1}",}}`,
+    cacheKey2: `${model2}~{"params":{"operation":"${action2}","args":{"where":{"foo":"bar"}},"model":"${model2}",}}`,
+  },
+])("createPrismaRedisCache function", ({ args, cacheTime, cacheKey1, cacheKey2 }) => {
+  test("should cache a single Prisma model", async () => {
+    const extension = createPrismaRedisCache({
+      cacheTime,
+      storage: { type: "redis", options: { client: redis } },
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Test if the data exists in the cache
+    expect(JSON.parse((await redis.get(cacheKey1)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should cache multiple Prisma models in cache", async () => {
+    const extension = createPrismaRedisCache({
+      models: [
+        { model: model1, cacheTime },
+        { model: model2, cacheTime },
+      ],
+      storage: { type: "redis", options: { client: redis } },
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if the data exists in the cache
+    expect(JSON.parse((await redis.get(cacheKey1)) as string)).toMatchObject(dbValue);
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should use custom cacheKey when caching a Prisma model", async () => {
+    const customCacheKey = "Article";
+    const cacheKey = `${customCacheKey}~{"params":{"operation":"${action1}","args":{"where":{"foo":"bar"}},"model":${customCacheKey},}}`;
+
+    const extension = createPrismaRedisCache({
+      models: [{ model: model1, cacheKey: customCacheKey }],
+      storage: { type: "redis", options: { client: redis } },
+      cacheTime,
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Test if the query was skipped and does not exist in cache
+    assert.equal(JSON.parse((await redis.get(cacheKey)) as string), null);
+  });
+
+  test("should exclude Prisma operation from being cached with individual model excludeMethods", async () => {
+    const extension = createPrismaRedisCache({
+      models: [{ model: model1, cacheTime, excludeMethods: [action1] }],
+      storage: { type: "redis", options: { client: redis } },
+      cacheTime,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Test if the query was skipped and does not exist in cache
+    assert.equal(JSON.parse((await redis.get(cacheKey1)) as string), null);
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should exclude a Prisma method from being cached with default excludeMethods", async () => {
+    const extension = createPrismaRedisCache({
+      models: [{ model: model1 }],
+      storage: { type: "redis", options: { client: redis } },
+      cacheTime,
+      excludeMethods: [action1],
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if the query was skipped and does not exist in cache
+    assert.equal(JSON.parse((await redis.get(cacheKey1)) as string), null);
+    // Test that (non-excluded) queries are still cached
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should exclude a Prisma model from being cached with excludeModels", async () => {
+    const extension = createPrismaRedisCache({
+      storage: { type: "redis", options: { client: redis } },
+      cacheTime,
+      excludeModels: [model1],
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if the Model was skipped and does not exist in cache
+    assert.equal(JSON.parse((await redis.get(cacheKey1)) as string), null);
+    // Make sure that other (non-excluded) models are still cached
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should invalidate a single Prisma model cache after data mutation", async () => {
+    const extension = createPrismaRedisCache({
+      storage: { type: "redis", options: { client: redis, invalidation: true } },
+      cacheTime,
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if data exists in the cache
+    expect(JSON.parse((await redis.get(cacheKey1)) as string)).toMatchObject(dbValue);
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+
+    // Run a "fake" User Prisma mutation
+    await extension({
+      args,
+      operation: "create",
+      model: model1,
+    });
+
+    // Test if the cache was invalidated and cleared properly
+    assert.equal(JSON.parse((await redis.get(cacheKey1)) as string), null);
+    // Test that we keep other cached queries that shouldn't be cleared
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+  });
+
+  test("should invalidate a Prisma model cache and related Prisma models after data mutation", async () => {
+    const extension = createPrismaRedisCache({
+      models: [
+        {
+          model: model1,
+          invalidateRelated: [model2],
+        },
+      ],
+      storage: { type: "redis", options: { client: redis, invalidation: true } },
+      cacheTime,
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if data exists in the cache
+    expect(JSON.parse((await redis.get(cacheKey1)) as string)).toMatchObject(dbValue);
+    expect(JSON.parse((await redis.get(cacheKey2)) as string)).toMatchObject(dbValue);
+
+    // Run a "fake" User Prisma mutation
+    await extension({
+      args,
+      operation: "create",
+      model: model1,
+    });
+
+    // Test if the cache was invalidated and cleared properly
+    assert.equal(JSON.parse((await redis.get(cacheKey1)) as string), null);
+    assert.equal(JSON.parse((await redis.get(cacheKey2)) as string), null);
+  });
+
+  test("should not invalidate a Prisma model if cache method is excluded", async () => {
+    const extension = createPrismaRedisCache({
+      storage: { type: "redis", options: { client: redis, invalidation: true } },
+      cacheTime,
+      excludeMethods: ["findFirst"],
+    });
+
+    // Run a "fake" User Prisma query
+    await extension({
+      args,
+      operation: action1,
+      model: model1,
+    });
+
+    // Run a "fake" Post Prisma query
+    await extension({
+      args,
+      operation: action2,
+      model: model2,
+    });
+
+    // Test if the cached query was fetched from the cache
+    expect(JSON.parse((await redis.get(cacheKey1)) as string)).toMatchObject(dbValue);
+    // Test that the excluded cache method was not cached
+    assert.equal(JSON.parse((await redis.get(cacheKey2)) as string), null);
+  });
+});


### PR DESCRIPTION
This PR migrates the package from Prisma middleware to Prisma Client extensions because middleware was deprecated in v4.16.0.

Would we separate `prisma-redis-middleware` into two packages: a middleware & a client extension, or migrate the middleware to Prisma Client extensions? The latter would be a breaking change, and the former would be a safe alternative for those who would still like to use it as middleware.

Happy to hear your thoughts and make any necessary changes.

Most of the code was reusable from the middleware with a few minor tweaks such as argument names.

TODO: 
- [ ] Add tests

Closes #546 