### PR TITLE
fix(cacheMethods): there should be executeRaw in defaultMutationMethods

### DIFF
--- a/src/cacheMethods.ts
+++ b/src/cacheMethods.ts
@@ -20,4 +20,5 @@ export const defaultMutationMethods: PrismaMutationAction[] = [
   "delete",
   "deleteMany",
   "executeRaw",
+  "executeRawUnsafe"
 ];

--- a/src/cacheMethods.ts
+++ b/src/cacheMethods.ts
@@ -19,5 +19,5 @@ export const defaultMutationMethods: PrismaMutationAction[] = [
   "upsert",
   "delete",
   "deleteMany",
-  "executeRawUnsafe",
+  "executeRaw",
 ];


### PR DESCRIPTION
- fix(cacheMethods): it is executeRaw even if you execute executeRawUnsafe
The params.action would be executeRaw even if you execute executeRawUnsafe
- fix(cacheMethods): add executeRawUnsafe too for compatibility
As mentioned in the issue, I'm not sure if Prisma v4 params.action is executeRaw even on executeRawUnsafe. For compatibility, let's add both
